### PR TITLE
Revert "Use Maven 3.3"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vesp
         llvm3.9-static \
         lz4-devel \
         make \
-        rh-maven33 \
+        maven \
         openssl \
         openssl-devel \
         perl \
@@ -40,7 +40,6 @@ RUN yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vesp
         'vespa-zookeeper-c-client-devel >= 3.4.9-6' \
         zlib-devel && \
     yum clean all && \
-    scl enable rh-maven33 bash && \
     echo "source /opt/rh/devtoolset-6/enable" > /etc/profile.d/devtoolset-6.sh && \
     echo "*          soft    nproc     32768" > /etc/security/limits.d/90-nproc.conf
 


### PR DESCRIPTION
Reverts vespa-engine/docker-image-dev#5

Travis-CI build no longer able to find _mvn_ binary.
I will revert the latest changes to vespa.spec file as well. 

FYI @aressem.