### PR TITLE
Add support for ed25519 keys and fix perms

### DIFF
--- a/dev/centos7/configure-container.sh
+++ b/dev/centos7/configure-container.sh
@@ -16,6 +16,9 @@ docker exec -it $container_name bash -c "echo '$(id -un) ALL=(ALL) NOPASSWD: ALL
 # Ensure home directory has correct owner and group
 docker exec -it $container_name bash -c "chown $(id -u):$(id -g) /home/$(id -un)"
 
+# Ensure home directory has correct permissions
+docker exec -it $container_name bash -c "chmod 755 /home/$(id -un)"
+
 # Copy authorized keys
 docker exec -u "$(id -u):$(id -g)" -it $container_name bash -c "mkdir -p /home/$(id -un)/.ssh"
 
@@ -23,8 +26,10 @@ if test -f $HOME/.ssh/authorized_keys; then
   docker cp -a $HOME/.ssh/authorized_keys $container_name:/home/$(id -un)/.ssh/
 elif test -f $HOME/.ssh/id_rsa.pub; then
   docker cp -a $HOME/.ssh/id_rsa.pub $container_name:/home/$(id -un)/.ssh/authorized_keys
+elif test -f $HOME/.ssh/id_ed25519.pub; then
+   docker cp -a $HOME/.ssh/id_ed25519.pub $container_name:/home/$(id -un)/.ssh/authorized_keys
 else
-  echo "No authorized keys found in $HOME/.ssh"
+  echo "ERROR: No authorized keys found in $HOME/.ssh"
   exit 1
 fi
 


### PR DESCRIPTION
Github updated their ssh key generation instructions to output ed25519
keys - Add support for that format so the readme instructions work
again.

Also, ensure the home directory has correct permissions as users will
not be able to ssh in if the mounted volume is group writable etc

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

fixes vespa-engine/vespa#17208