### PR TITLE
additional step to make sure Docker can be executed without sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Make sure Docker can be executed without sudo for the scripts in this guide to w
     sudo usermod -aG docker $(id -un)
     sudo systemctl restart docker
     
-Log out and login again; or run `newgrp docker` command to continue.
+Log out and login again; or run `sudo su - $USER` command to continue.
 
 ### Setup the Docker container
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ Make sure Docker can be executed without sudo for the scripts in this guide to w
     sudo groupadd docker
     sudo usermod -aG docker $(id -un)
     sudo systemctl restart docker
-    newgrp docker
-
-Perform a new ssh login to the host.
-
+    
+Log out and login again; or run `newgrp docker` command to continue.
 
 ### Setup the Docker container
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Make sure Docker can be executed without sudo for the scripts in this guide to w
     sudo groupadd docker
     sudo usermod -aG docker $(id -un)
     sudo systemctl restart docker
+    newgrp docker
 
 Perform a new ssh login to the host.
 


### PR DESCRIPTION
An additional command is needed to make sure Docker can be executed without sudo.
Without running this command, the "docker create" command in the documentation fails with the error: "Got permission denied while trying to connect to the Docker daemon socket at unix .. : connect: permission denied"

Environment tested on: Ubuntu 20.04.2 LTS and Ubuntu 18.04.5 LTS

Referenced in https://github.com/vespa-engine/vespa/issues/17208

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.