### PR TITLE
Add pybind 11 build requires (via updated git ref to use newer

### DIFF
--- a/build/centos7/Dockerfile
+++ b/build/centos7/Dockerfile
@@ -15,7 +15,7 @@ RUN yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vesp
 ENV GIT_REPO "https://github.com/vespa-engine/vespa.git"
 
 # Change git reference for a specific version of the vespa.spec file. Use a tag or SHA to allow for reproducible builds.
-ENV VESPA_SRC_REF "b40b4f2b0a928b373a14736d34cd2e7e0f97188a"
+ENV VESPA_SRC_REF "813ff619c01b29029e96957f60967be63b26f6ce"
 
 # Install vespa build and runtime dependencies
 RUN git clone $GIT_REPO && cd vespa && git -c advice.detachedHead=false checkout $VESPA_SRC_REF && \


### PR DESCRIPTION
version of vespa.spec file).

@aressem : please review
