### PR TITLE
Enable rh-ruby27 by default on CentOS 7.

### DIFF
--- a/dev/centos7/Dockerfile
+++ b/dev/centos7/Dockerfile
@@ -35,7 +35,8 @@ RUN yum -y clean all && \
     (source /opt/rh/devtoolset-10/enable && \
      source /opt/rh/rh-ruby27/enable && \
      gem install libxml-ruby gnuplot distribution test-unit builder concurrent-ruby ffi) && \
-    yum clean all --enablerepo=\*
+    yum clean all --enablerepo=\* && \
+    echo -e "#!/bin/bash\nsource /opt/rh/rh-ruby27/enable" >> /etc/profile.d/enable-rh-ruby27.sh
 
 STOPSIGNAL SIGRTMIN+3
 


### PR DESCRIPTION
@aressem : please review
@geirst : FYI
