### PR TITLE
Add pinentry.

### DIFF
--- a/build/centos-stream8/Dockerfile
+++ b/build/centos-stream8/Dockerfile
@@ -9,12 +9,13 @@ RUN dnf -y install epel-release && \
     dnf -y copr enable @vespa/vespa centos-stream-8 && \
     dnf config-manager --enable powertools && \
     dnf -y install \
+        ccache \
         git \
         hostname \
         iputils \
         java-17-openjdk-devel \
         jq \
-        ccache \
+        pinentry \
         sudo
 
 ENV GIT_REPO "https://github.com/vespa-engine/vespa.git"


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The sonatype nexus plugin uses this and is required to upload to Maven Central. This was default installed in the CentOS 7 image.
