### PR TITLE
Bump spec commit refs to include OpenSSL 1.1.1o for dev images

### DIFF
--- a/build/centos-stream8/Dockerfile
+++ b/build/centos-stream8/Dockerfile
@@ -21,7 +21,7 @@ RUN dnf -y install epel-release && \
 ENV GIT_REPO "https://github.com/vespa-engine/vespa.git"
 
 # Change git reference for a specific version of the vespa.spec file. Use a tag or SHA to allow for reproducible builds.
-ENV VESPA_SRC_REF "1e84bb8d7b54889879e2acb34361fd25deb8ab95"
+ENV VESPA_SRC_REF "704f95e5b7592577f2d45e905666e073646bcfaf"
 
 # Install vespa build and runtime dependencies
 RUN git clone $GIT_REPO && cd vespa && git -c advice.detachedHead=false checkout $VESPA_SRC_REF && \

--- a/build/centos7/Dockerfile
+++ b/build/centos7/Dockerfile
@@ -15,7 +15,7 @@ RUN yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vesp
 ENV GIT_REPO "https://github.com/vespa-engine/vespa.git"
 
 # Change git reference for a specific version of the vespa.spec file. Use a tag or SHA to allow for reproducible builds.
-ENV VESPA_SRC_REF "1e84bb8d7b54889879e2acb34361fd25deb8ab95"
+ENV VESPA_SRC_REF "704f95e5b7592577f2d45e905666e073646bcfaf"
 
 # Install vespa build and runtime dependencies
 RUN git clone $GIT_REPO && cd vespa && git -c advice.detachedHead=false checkout $VESPA_SRC_REF && \


### PR DESCRIPTION
@toregge please review. @geirst FYI.

New ref points to https://github.com/vespa-engine/vespa/commit/704f95e5b7592577f2d45e905666e073646bcfaf