### PR TITLE
Add gcc-toolset-11-libubsan-devel to centos stream 8 vespa build image.

### DIFF
--- a/build/centos-stream8/Dockerfile
+++ b/build/centos-stream8/Dockerfile
@@ -40,6 +40,7 @@ RUN dnf -y module enable ruby:3.0 && \
         gcc-toolset-11-annobin-plugin-gcc \
         gcc-toolset-11-libasan-devel \
         gcc-toolset-11-libtsan-devel \
+        gcc-toolset-11-libubsan-devel \
         libffi-devel \
         libxml2-devel \
         ruby \


### PR DESCRIPTION
@aressem : please review
@vekterli : FYI
