### PR TITLE
Use gcc 12 and g++ 12 on Ubuntu 22.04.

### DIFF
--- a/experimental/ubuntu-22/Dockerfile
+++ b/experimental/ubuntu-22/Dockerfile
@@ -43,7 +43,7 @@ RUN cd /opt/vespa-deps && ln -sf lib lib64
 
 # basic C++ developement:
 RUN apt-get -y install git
-RUN apt-get -y install gcc g++ gdb llvm
+RUN apt-get -y install gcc-12 'g\+\+-12' gdb llvm
 RUN apt-get -y install make cmake ccache
 RUN apt-get -y install bison flex
 


### PR DESCRIPTION
@arnej27959 : please review
