### PR TITLE
Revert "Add python3-pip to dev image"

### DIFF
--- a/dev/almalinux-8/Dockerfile
+++ b/dev/almalinux-8/Dockerfile
@@ -15,7 +15,6 @@ RUN dnf -y install \
         man-pages \
         hunspell-en \
         kdesdk-kcachegrind \
-        python3-pip \
         graphviz && \
     pip3 install --upgrade pip && \
     pip3 install numpy xgboost scikit-learn && \


### PR DESCRIPTION
Reverts vespa-engine/docker-image-dev#239

I wonder if this broke the build, because `python` could no longer find a `requests` module? 