### PR TITLE
Use system gdb for almalinux 9.

### DIFF
--- a/dev/almalinux-9/Dockerfile
+++ b/dev/almalinux-9/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf -y install \
         vim \
         wget \
         emacs \
-        gcc-toolset-13-gdb \
+        gdb \
         man-db \
         man-pages \
         hunspell-en \
@@ -21,7 +21,6 @@ RUN dnf -y install \
         graphviz && \
     pip3 install --upgrade pip && \
     pip3 install numpy xgboost scikit-learn && \
-    printf '%s\n'  "# gdb"  "source /opt/rh/gcc-toolset-13/enable"  > /etc/profile.d/enable-gcc-toolset-13-gdb.sh && \
     dnf clean all --enablerepo=\* 
 
 RUN useradd -M -d /opt/vespa -s /usr/sbin/nologin vespa


### PR DESCRIPTION
system gdb is rebased and newer than gdb from gcc-toolset-13.

@aressem : Please review
