### PR TITLE
fix ssh configuration for dev image

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If not, use the following guide
 
     mkdir -p $HOME/git
     cd $HOME/git
-    git clone git@github.com:vespa-engine/docker-image-dev.git
+    git clone https://github.com/vespa-engine/docker-image-dev.git
     cd $HOME/git/docker-image-dev/dev/almalinux-8
 
 If using Docker:
@@ -235,7 +235,7 @@ Default install directory is $HOME/vespa ($VESPA_HOME).
 #### Checkout system-test repo
 
     cd $HOME/git
-    git clone git@github.com:vespa-engine/system-test.git
+    git clone https://github.com/vespa-engine/system-test.git
 
 Note that the system test scrips are already in your PATH inside the Docker container.
 
@@ -251,8 +251,7 @@ Some system tests depend on feature flag overrides.
 
 #### Run system test in another terminal
 
-    cd $HOME/git/system-test/tests/search/basicsearch
-    runtest.sh basic_search.rb
+    runtest.sh $HOME/git/system-test/tests/search/basicsearch/basic_search.rb
 
 ### Building and running Vespa with sanitizer instrumentation
 

--- a/dev/almalinux-8/configure-container.sh
+++ b/dev/almalinux-8/configure-container.sh
@@ -23,14 +23,12 @@ $engine exec -it $container_name bash -c "chmod 755 /home/$(id -un)"
 # Copy authorized keys
 $engine exec -u "$(id -u):$(id -g)" -it $container_name bash -c "mkdir -p /home/$(id -un)/.ssh"
 
-if test -f $HOME/.ssh/authorized_keys; then
-  $engine cp -a $HOME/.ssh/authorized_keys $container_name:/home/$(id -un)/.ssh/
-elif test -f $HOME/.ssh/id_rsa.pub; then
+if test -f $HOME/.ssh/id_rsa.pub; then
   $engine cp -a $HOME/.ssh/id_rsa.pub $container_name:/home/$(id -un)/.ssh/authorized_keys
 elif test -f $HOME/.ssh/id_ed25519.pub; then
   $engine cp -a $HOME/.ssh/id_ed25519.pub $container_name:/home/$(id -un)/.ssh/authorized_keys
 else
-  echo "ERROR: No authorized keys found in $HOME/.ssh"
+  echo "ERROR: No public SSH keys found in $HOME/.ssh"
   exit 1
 fi
 $engine exec -it ${container_name} bash -c "chown $(id -un) /home/$(id -un)/.ssh/authorized_keys"


### PR DESCRIPTION
authorized_keys should not be taken from the client and put to the server's authorized_keys. Instead actual public keys should be used as an authorized key

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
