### PR TITLE
Fix config script

### DIFF
--- a/dev/almalinux-8/configure-container.sh
+++ b/dev/almalinux-8/configure-container.sh
@@ -43,7 +43,7 @@ $engine exec -u "$(id -u):$(id -g)" -it $container_name bash -c \
 'export PATH' \
 'export MAVEN_OPTS=\"-Xms128m -Xmx1024m\"' \
 'alias ctest=ctest3' \
-> ~/.docker_profile"
+>> ~/.docker_profile"
 $engine exec -u "$(id -u):$(id -g)" -it $container_name bash -c \
 "grep -q '.docker_profile' ~/.bash_profile || echo 'test -f ~/.docker_profile && source ~/.docker_profile || true' >> ~/.bash_profile"
 

--- a/dev/almalinux-9/configure-container.sh
+++ b/dev/almalinux-9/configure-container.sh
@@ -44,7 +44,7 @@ $engine exec -u "$(id -u):$(id -g)" -it $container_name bash -c \
 'export PATH' \
 'export MAVEN_OPTS=\"-Xms128m -Xmx1024m\"' \
 'alias ctest=ctest3' \
-> ~/.docker_profile"
+>> ~/.docker_profile"
 $engine exec -u "$(id -u):$(id -g)" -it $container_name bash -c \
 "grep -q '.docker_profile' ~/.bash_profile || echo 'test -f ~/.docker_profile && source ~/.docker_profile || true' >> ~/.bash_profile"
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Previous version did not work as bash_profile for user does not exist. 

```bash
thomas@Thomass-MBP almalinux-8 % ./configure-container.sh podman vespa-dev-almalinux-8
groupadd: GID '20' already exists
useradd: warning: the home directory already exists.
Not copying any file from skel directory into it.
grep: /home/thomas/.bash_profile: No such file or directory
```

This caused ssh connection to close immediately.