### PR TITLE
feat(almalinux-9): move setup steps to scripts for modularity

### DIFF
--- a/dev/almalinux-9/Dockerfile
+++ b/dev/almalinux-9/Dockerfile
@@ -2,27 +2,9 @@
 
 FROM docker.io/vespaengine/vespa-build-almalinux-9:latest
 
-# Install sshd, man-db, nice-to-have packages and system test dependencies
-RUN dnf -y install \
-        bind-utils \
-        openssh-server \
-        xorg-x11-xauth \
-        rsync \
-        nmap-ncat \
-        vim \
-        wget \
-        emacs \
-        gdb \
-        man-db \
-        man-pages \
-        hunspell-en \
-        kdesdk-kcachegrind \
-        python3-pip \
-        graphviz && \
-    pip3 install --upgrade pip && \
-    pip3 install numpy xgboost scikit-learn && \
-    dnf clean all --enablerepo=\* 
+RUN --mount=type=bind,target=/include/,source=include/,rw /bin/sh /include/setup.sh
 
+# Add default user
 RUN useradd -M -d /opt/vespa -s /usr/sbin/nologin vespa
 
 STOPSIGNAL SIGRTMIN+3

--- a/dev/almalinux-9/include/setup-python.sh
+++ b/dev/almalinux-9/include/setup-python.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <python-version>"
+  exit 1
+fi
+
+PYTHON_VERSION="${1}"
+if [[ ! "$PYTHON_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid Python version format. Please use 'X.Y' format."
+  exit 1
+fi
+
+echo "Install Python and pip"
+dnf -y install "python${PYTHON_VERSION}" "python${PYTHON_VERSION}-pip"
+
+
+echo "Install alternatives for python3 and pip3"
+alternatives --install /usr/bin/python3 python3 "/usr/bin/python${PYTHON_VERSION}" 1 \
+  --slave /usr/bin/pip3 pip3 "/usr/bin/pip${PYTHON_VERSION}"
+
+echo "Set python3 to version '${PYTHON_VERSION}'"
+alternatives --set python3 "/usr/bin/python${PYTHON_VERSION}"
+
+echo "Upgrade pip.."
+pip3 install --upgrade pip
+
+echo "Python ${PYTHON_VERSION} and pip3 have been installed successfully."

--- a/dev/almalinux-9/include/setup.sh
+++ b/dev/almalinux-9/include/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Install sshd, man-db, nice-to-have packages and system test dependencies
+dnf -y install \
+  bind-utils \
+  xorg-x11-xauth \
+  rsync \
+  nmap-ncat \
+  vim \
+  wget \
+  gdb \
+  hunspell-en \
+  kdesdk-kcachegrind \
+  graphviz
+
+# Manage System Python
+"$(dirname "$0")/setup-python.sh" 3.12
+
+echo "Clean up..."
+dnf clean all --enablerepo=\*


### PR DESCRIPTION
## What

- Configure Almalinux 9 to use python 3.12
- Moved setup steps into separate scripts

## Why

- Default AL9 comes with python 3.9 and has removed support for `alternatives` on python.
  Ref: [RHEL Docs](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/installing_and_using_dynamic_programming_languages/assembly_installing-and-using-python_installing-and-using-dynamic-programming-languages)
- Follow up of https://github.com/vespa-engine/vespa/pull/34752