### PR TITLE
Upgraded university image to Ubuntu 24.04

### DIFF
--- a/university/101/Dockerfile
+++ b/university/101/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG TARGET_USER=student
 
@@ -23,6 +23,7 @@ RUN apt-get -y install unzip
 RUN apt-get -y install jq
 RUN apt-get -y install less
 RUN apt-get -y install vim emacs nano
+RUN apt-get -y install python3-venv
 
 ENV TARGET_USER=student
 ENV USER_HOME=/home/$TARGET_USER


### PR DESCRIPTION
Which seems to require python3-venv to make the Ranking training work properly. Could have been installed via script, but I think this is a base requirement.

Vespa 101 shouldn't be broken by this change. I've tested the Ranking training locally (which is more involved, dependency-wise) and nothing seems broken. Will smoke test again in Instruqt, once the image is published.

The new image is nicer for modern tools, most notably [VespaEmbed](https://github.com/vespaai-playground/vespaembed), which needs a newer Python version (3.11+, we had 3.10). 