### PR TITLE
Use vespa-engine.repo instead of COPR for build dependencies

### DIFF
--- a/build/almalinux-8/include/install-build-dependencies.sh
+++ b/build/almalinux-8/include/install-build-dependencies.sh
@@ -21,7 +21,7 @@ dnf -y install 'dnf-command(config-manager)'
 dnf config-manager --enable powertools
 case "$VESPADEV_RPM_SOURCE" in
     external)
-        dnf config-manager --add-repo=$GIT_REPO/raw/$GIT_REF/dist/vespa-engine.repo
+        dnf -y config-manager --add-repo=$GIT_REPO/raw/$GIT_REF/dist/vespa-engine.repo
         ;;
     test)
         /work/setup-test-repo

--- a/build/almalinux-8/include/install-build-dependencies.sh
+++ b/build/almalinux-8/include/install-build-dependencies.sh
@@ -10,11 +10,33 @@ fi
 
 VESPADEV_RPM_SOURCE="${1:-external}"
 
+# Change git reference for a specific version of the vespa.spec file. Use a tag or SHA to allow for reproducible builds.
+: ${GIT_REF:="master"}
+GIT_REPO="https://github.com/vespa-engine/vespa"
+
+# Enable and install repositories
+dnf -y install epel-release
+dnf -y install dnf-plugins-core dnf-plugin-ovl
+dnf -y install 'dnf-command(config-manager)'
+dnf config-manager --enable powertools
 case "$VESPADEV_RPM_SOURCE" in
-    external|test) ;;
-    *) echo "Bad \$VESPADEV_RPM_SOURCE: $VESPADEV_RPM_SOURCE" 1>&2
-       exit 1;;
+    external)
+        dnf config-manager --add-repo=$GIT_REPO/raw/$GIT_REF/dist/vespa-engine.repo
+        ;;
+    test)
+        /work/setup-test-repo
+        ;;
+    *)
+        echo "Bad \$VESPADEV_RPM_SOURCE: $VESPADEV_RPM_SOURCE" 1>&2
+        exit 1
+        ;;
 esac
+
+# Java requires proper locale for unicode
+export LANG=C.UTF-8
+
+# Use newest packages
+dnf -y upgrade
 
 # Install OpenTofu in the Build
 /include/install-opentofu.sh
@@ -31,21 +53,6 @@ gpgcheck=1
 repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOM
-
-# Enable and install repositories
-dnf -y install epel-release
-dnf -y install dnf-plugins-core dnf-plugin-ovl
-case "$VESPADEV_RPM_SOURCE" in
-    external) dnf -y copr enable @vespa/vespa "epel-8-$(arch)";;
-    test) /work/setup-test-repo;;
-esac
-dnf config-manager --enable powertools
-
-# Java requires proper locale for unicode
-export LANG=C.UTF-8
-
-# Use newest packages
-dnf -y upgrade
 
 # Use newer maven
 dnf -y module enable maven:3.8
@@ -64,11 +71,6 @@ dnf -y install \
     sudo \
     time \
     valgrind
-
-GIT_REPO="https://github.com/vespa-engine/vespa"
-
-# Change git reference for a specific version of the vespa.spec file. Use a tag or SHA to allow for reproducible builds.
-: ${GIT_REF:="master"}
 
 # Fetch the RPM spec for vespa
 curl -Lf -O $GIT_REPO/raw/$GIT_REF/dist/vespa.spec

--- a/build/almalinux-9/include/install-build-dependencies.sh
+++ b/build/almalinux-9/include/install-build-dependencies.sh
@@ -8,24 +8,29 @@ if [[ "${DEBUG:-no}" == "true" ]]; then
     set -o xtrace
 fi
 
-set -xeu
-
 VESPADEV_RPM_SOURCE="${1:-external}"
 
-case "$VESPADEV_RPM_SOURCE" in
-    external|test) ;;
-    *) echo "Bad \$VESPADEV_RPM_SOURCE: $VESPADEV_RPM_SOURCE" 1>&2
-       exit 1;;
-esac
+# Change git reference for a specific version of the vespa.spec file. Use a tag or SHA to allow for reproducible builds.
+: ${GIT_REF:="master"}
+GIT_REPO="https://github.com/vespa-engine/vespa"
 
 # Enable and install repositories
 dnf -y install epel-release
 dnf -y install dnf-plugins-core
-case "$VESPADEV_RPM_SOURCE" in
-    external) dnf -y copr enable @vespa/vespa "epel-9-$(arch)";;
-    test) /work/setup-test-repo;;
-esac
+dnf -y install 'dnf-command(config-manager)'
 dnf config-manager --enable crb
+case "$VESPADEV_RPM_SOURCE" in
+    external)
+        dnf config-manager --add-repo=$GIT_REPO/raw/$GIT_REF/dist/vespa-engine.repo
+        ;;
+    test)
+        /work/setup-test-repo
+        ;;
+    *)
+        echo "Bad \$VESPADEV_RPM_SOURCE: $VESPADEV_RPM_SOURCE" 1>&2
+        exit 1
+        ;;
+esac
 
 # Java requires proper locale for unicode
 export LANG=C.UTF-8
@@ -51,11 +56,6 @@ dnf -y install \
     sudo \
     time \
     valgrind
-
-GIT_REPO="https://github.com/vespa-engine/vespa"
-
-# Change git reference for a specific version of the vespa.spec file. Use a tag or SHA to allow for reproducible builds.
-: ${GIT_REF:="master"}
 
 # Fetch the RPM spec for vespa
 curl -Lf -O $GIT_REPO/raw/$GIT_REF/dist/vespa.spec

--- a/build/almalinux-9/include/install-build-dependencies.sh
+++ b/build/almalinux-9/include/install-build-dependencies.sh
@@ -21,7 +21,7 @@ dnf -y install 'dnf-command(config-manager)'
 dnf config-manager --enable crb
 case "$VESPADEV_RPM_SOURCE" in
     external)
-        dnf config-manager --add-repo=$GIT_REPO/raw/$GIT_REF/dist/vespa-engine.repo
+        dnf -y config-manager --add-repo=$GIT_REPO/raw/$GIT_REF/dist/vespa-engine.repo
         ;;
     test)
         /work/setup-test-repo


### PR DESCRIPTION
The almalinux-8 and almalinux-9 build images pulled Vespa build dependencies from the @vespa/vespa COPR project. COPR is a community build service that is not an officially supported distribution channel and has had availability/reliability issues, so replace it with the official vespa-engine.repo published in the vespa repo.

For the 'external' RPM source, enable the repo via 'dnf config-manager --add-repo .../dist/vespa-engine.repo' instead of 'dnf copr enable @vespa/vespa'.

While here, consolidate the repository setup at the top of each script: move the GIT_REPO/GIT_REF definitions up, fold the RPM-source validation into the same case statement that selects the repo, and (al-9) drop the redundant 'set -xeu' since errexit/nounset are already enabled and xtrace is gated behind DEBUG. The two scripts are now structurally consistent.
